### PR TITLE
support for xhr uploads.

### DIFF
--- a/test/uploading_test.js
+++ b/test/uploading_test.js
@@ -1,0 +1,25 @@
+var upload;
+module("open", {
+  setup: function(){
+    upload = new FakeXMLHttpRequest().upload;
+  },
+  teardown: function(){
+    upload = undefined;
+  }
+});
+
+test("the upload property of a fake xhr is defined", function() {
+  ok(upload);
+})
+
+test("triggers the onprogress event", function() {
+  var event;
+  upload.onprogress = function(e) {
+    event = e;
+  };
+  upload._progress(true, 10, 100);
+  ok(event, "no event was fired on upload progress");
+  ok(event.lengthComputable, "ProgressEvent.lengthComputable");
+  equal(event.loaded, 10, "ProgressEvent.loaded");
+  equal(event.total, 100, "ProgressEvent.total");
+});


### PR DESCRIPTION
Extracted the ProgressEventTarget interface into a superclass since both
XMLHttpRequest and XMLHttpRequestUpload objects emit the same series of
events (loadstart, progress, load, abort, loadend)